### PR TITLE
Load assets lazily and unload them eagerly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ glTF2Image is a package for rendering screenshots or thumbnail images of 3D mode
 await using var renderer = await Renderer.CreateAsync();
 
 // Load the model.
-await using var model = await renderer.LoadGLTFAssetAsync(File.ReadAllBytes(Path.Join(TestDataPath, "Avocado.glb")));
+await using var model = renderer.CreateGLTFAsset(File.ReadAllBytes(Path.Join(TestDataPath, "Avocado.glb")));
 
 // Load another gltf model defining the lights and camera.
-await using var lightsAndCamera = await renderer.LoadGLTFAssetAsync(File.ReadAllBytes(Path.Join(TestDataPath, "avocado_lights_and_camera.gltf")));
+await using var lightsAndCamera = renderer.CreateGLTFAsset(File.ReadAllBytes(Path.Join(TestDataPath, "avocado_lights_and_camera.gltf")));
 
 // Render the scene.
 int width = 576;

--- a/managed/GLTF2Image.SampleApp/Program.cs
+++ b/managed/GLTF2Image.SampleApp/Program.cs
@@ -17,10 +17,10 @@ namespace GLTF2Image.SampleApp
             await using var renderer = await Renderer.CreateAsync();
 
             // Load the model.
-            await using var model = await renderer.LoadGLTFAssetAsync(File.ReadAllBytes(Path.Join(TestDataPath, "Avocado.glb")));
+            await using var model = renderer.CreateGLTFAsset(File.ReadAllBytes(Path.Join(TestDataPath, "Avocado.glb")));
             
             // Load another gltf model defining the lights and camera.
-            await using var lightsAndCamera = await renderer.LoadGLTFAssetAsync(File.ReadAllBytes(Path.Join(TestDataPath, "avocado_lights_and_camera.gltf")));
+            await using var lightsAndCamera = renderer.CreateGLTFAsset(File.ReadAllBytes(Path.Join(TestDataPath, "avocado_lights_and_camera.gltf")));
 
             // Render the scene.
             int width = 576;

--- a/managed/GLTF2Image/GLTFAsset.cs
+++ b/managed/GLTF2Image/GLTFAsset.cs
@@ -5,13 +5,19 @@ namespace GLTF2Image
 {
     public sealed class GLTFAsset : IDisposable, IAsyncDisposable
     {
-        private Renderer _renderer;
+        private readonly Renderer _renderer;
+        internal ReadOnlyMemory<byte> _data;
+        internal readonly bool _keepLoadedForMultipleRenders;
+
         internal nint _handle;
 
-        internal GLTFAsset(Renderer renderer, nint handle)
+        internal bool IsLoaded => _handle != 0;
+
+        internal GLTFAsset(Renderer renderer, ReadOnlyMemory<byte> data, bool keepLoadedForMultipleRenders)
         {
             _renderer = renderer;
-            _handle = handle;
+            _data = data;
+            _keepLoadedForMultipleRenders = keepLoadedForMultipleRenders;
         }
 
         ~GLTFAsset()
@@ -26,7 +32,10 @@ namespace GLTF2Image
 
         public async ValueTask DisposeAsync()
         {
-            await _renderer.DestroyGLTFAssetAsync(this);
+            if (IsLoaded)
+            {
+                await _renderer.DestroyGLTFAssetAsync(this);
+            }
             GC.SuppressFinalize(this);
         }
     }


### PR DESCRIPTION
Change the API to reduce the number of assets that are loaded into the engine at once. Avoid loading assets until they're actually needed in a call to RenderAsync. Unload assets right after rendering unless the user has flagged the asset for use in multiple renders. 