### PR TITLE
Update to .NET 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ Filament has good support for many glTF features and extensions. There are a sma
 - Only one directional light is [supported](https://github.com/google/filament/blob/c93aa4c90df7a814a076ebc8d92cc94d4fa96910/filament/include/filament/LightManager.h#L89)
 
 ## Requirements
-- .NET 6 or later
+- .NET 8 or later
 - Windows or Linux
 - x64

--- a/managed/GLTF2Image.SampleApp/GLTF2Image.SampleApp.csproj
+++ b/managed/GLTF2Image.SampleApp/GLTF2Image.SampleApp.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/managed/GLTF2Image.SampleApp/Program.cs
+++ b/managed/GLTF2Image.SampleApp/Program.cs
@@ -6,7 +6,7 @@ namespace GLTF2Image.SampleApp
 {
     internal class Program
     {
-        private static string TestDataPath => Path.Join(Path.GetDirectoryName(typeof(Program).Assembly.Location), "TestData");
+        private static string TestDataPath => Path.Join(AppContext.BaseDirectory, "TestData");
 
         static async Task Main(string[] args)
         {

--- a/managed/GLTF2Image.Tests/GLTF2Image.Tests.csproj
+++ b/managed/GLTF2Image.Tests/GLTF2Image.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/managed/GLTF2Image.Tests/GLTF2Image.Tests.csproj
+++ b/managed/GLTF2Image.Tests/GLTF2Image.Tests.csproj
@@ -15,9 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/managed/GLTF2Image.Tests/RendererTests.cs
+++ b/managed/GLTF2Image.Tests/RendererTests.cs
@@ -178,7 +178,7 @@ namespace GLTF2Image.Tests
             Assert.True(gotExpectedMessage);
         }
 
-        private static string TestDataPath => Path.Join(Path.GetDirectoryName(typeof(RendererTests).Assembly.Location), "TestData");
+        private static string TestDataPath => Path.Join(AppContext.BaseDirectory, "TestData");
 
         private static Color GetPixelColor(ReadOnlySpan<byte> rgbaPixelData, int width, int height, int x, int y)
         {

--- a/managed/GLTF2Image/GLTF2Image.csproj
+++ b/managed/GLTF2Image/GLTF2Image.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/managed/GLTF2Image/NativeMethods.cs
+++ b/managed/GLTF2Image/NativeMethods.cs
@@ -4,22 +4,22 @@ using System.Runtime.InteropServices;
 
 namespace GLTF2Image
 {
-    internal static class NativeMethods
+    internal static partial class NativeMethods
     {
-        [DllImport("gltf2image_native")]
-        public static unsafe extern uint createRenderManager(out nint renderManager);
+        [LibraryImport("gltf2image_native")]
+        public static unsafe partial uint createRenderManager(out nint renderManager);
 
-        [DllImport("gltf2image_native")]
-        public static extern uint destroyRenderManager(nint renderManager);
+        [LibraryImport("gltf2image_native")]
+        public static partial uint destroyRenderManager(nint renderManager);
 
-        [DllImport("gltf2image_native")]
-        public static unsafe extern uint loadGLTFAsset(nint renderManager, byte* data, uint size, out nint gltfAsset);
+        [LibraryImport("gltf2image_native")]
+        public static unsafe partial uint loadGLTFAsset(nint renderManager, byte* data, uint size, out nint gltfAsset);
 
-        [DllImport("gltf2image_native")]
-        public static extern uint destroyGLTFAsset(nint renderManager, nint gltfAsset);
+        [LibraryImport("gltf2image_native")]
+        public static partial uint destroyGLTFAsset(nint renderManager, nint gltfAsset);
 
-        [DllImport("gltf2image_native")]
-        public static unsafe extern uint render(
+        [LibraryImport("gltf2image_native")]
+        public static unsafe partial uint render(
             nint renderManager,
             uint width,
             uint height,
@@ -39,8 +39,8 @@ namespace GLTF2Image
             Error = 4,
         }
 
-        [DllImport("gltf2image_native")]
-        public static unsafe extern uint setLogCallback(delegate* unmanaged<LogLevel, byte*, nint, void> callback, nint user);
+        [LibraryImport("gltf2image_native")]
+        public static unsafe partial uint setLogCallback(delegate* unmanaged<LogLevel, byte*, nint, void> callback, nint user);
 
         public static void ThrowIfNativeApiFailed(uint nativeApiResult)
         {


### PR DESCRIPTION
Update to .NET 8, dropping support for .NET 6. Enable NativeAot publishing on the sample app. Update NuGet dependencies.