### PR TITLE
Add contents write permissions to the GitHub token

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,8 @@ jobs:
   package:
     needs: build
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
This is needed for the build action to be able to upload a .nupkg to a release.