### PR TITLE
Add BLIT_SRC texture usage explicitly

### DIFF
--- a/native/gltf2image/RenderManager.cpp
+++ b/native/gltf2image/RenderManager.cpp
@@ -55,7 +55,7 @@ struct RenderResult
             .levels(1)
             .sampler(Texture::Sampler::SAMPLER_2D)
             .format(Texture::InternalFormat::RGBA8)
-            .usage(Texture::Usage::COLOR_ATTACHMENT)
+            .usage(Texture::Usage::COLOR_ATTACHMENT | Texture::Usage::BLIT_SRC)
             .build(*engine);
     }
 


### PR DESCRIPTION
Address the following warning which Filament has started printing to the warning log:

`readPixels() must be called with a renderTarget with COLOR0 created with TextureUsage::BLIT_SRC.  This precondition will be asserted in a later release of Filament.`